### PR TITLE
feat: add uniswap v3 support

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	version = "0.1.0"
+	version = "0.2.0"
 )
 
 func main() {
@@ -55,8 +55,9 @@ func main() {
 
 	// Initialize DEX clients
 	uniswapV2 := dex.NewUniswapV2Client(ethClient)
+	uniswapV3 := dex.NewUniswapV3Client(ethClient)
 	sushiswap := dex.NewSushiswapClient(ethClient)
-	dexClients := []dex.DEXClient{uniswapV2, sushiswap}
+	dexClients := []dex.DEXClient{uniswapV2, uniswapV3, sushiswap}
 
 	// Initialize services
 	priceService := services.NewPriceService(dexClients, cacheClient)

--- a/configs/tokens.json
+++ b/configs/tokens.json
@@ -1,0 +1,52 @@
+{
+  "tokens": [
+    {
+      "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      "symbol": "WETH",
+      "name": "Wrapped Ether",
+      "decimals": 18
+    },
+    {
+      "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "symbol": "USDC",
+      "name": "USD Coin",
+      "decimals": 6
+    },
+    {
+      "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+      "symbol": "USDT",
+      "name": "Tether USD",
+      "decimals": 6
+    },
+    {
+      "address": "0x6B175474E89094C44Da98b954EesfdfdAD3Ef9FB",
+      "symbol": "DAI",
+      "name": "Dai Stablecoin",
+      "decimals": 18
+    },
+    {
+      "address": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+      "symbol": "WBTC",
+      "name": "Wrapped BTC",
+      "decimals": 8
+    },
+    {
+      "address": "0x514910771AF9Ca656af840dff83E8264EcF986CA",
+      "symbol": "LINK",
+      "name": "ChainLink Token",
+      "decimals": 18
+    },
+    {
+      "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+      "symbol": "UNI",
+      "name": "Uniswap",
+      "decimals": 18
+    },
+    {
+      "address": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
+      "symbol": "AAVE",
+      "name": "Aave Token",
+      "decimals": 18
+    }
+  ]
+}

--- a/internal/domain/entities/pair_test.go
+++ b/internal/domain/entities/pair_test.go
@@ -1,0 +1,192 @@
+package entities
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestGetSpotPrice(t *testing.T) {
+	tests := []struct {
+		name     string
+		reserve0 *big.Int
+		reserve1 *big.Int
+		want     string
+	}{
+		{
+			name:     "equal reserves",
+			reserve0: big.NewInt(1000000),
+			reserve1: big.NewInt(1000000),
+			want:     "1000000000000000000", // 1e18
+		},
+		{
+			name:     "2x price ratio",
+			reserve0: big.NewInt(1000000),
+			reserve1: big.NewInt(2000000),
+			want:     "2000000000000000000", // 2e18
+		},
+		{
+			name:     "0.5x price ratio",
+			reserve0: big.NewInt(2000000),
+			reserve1: big.NewInt(1000000),
+			want:     "500000000000000000", // 0.5e18
+		},
+		{
+			name:     "zero reserve0",
+			reserve0: big.NewInt(0),
+			reserve1: big.NewInt(1000000),
+			want:     "0",
+		},
+		{
+			name:     "nil reserves",
+			reserve0: nil,
+			reserve1: nil,
+			want:     "0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Pair{
+				Reserve0: tt.reserve0,
+				Reserve1: tt.reserve1,
+			}
+			got := p.GetSpotPrice()
+			if got.String() != tt.want {
+				t.Errorf("GetSpotPrice() = %v, want %v", got.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestGetAmountOut(t *testing.T) {
+	token0 := common.HexToAddress("0x0000000000000000000000000000000000000001")
+	token1 := common.HexToAddress("0x0000000000000000000000000000000000000002")
+
+	tests := []struct {
+		name      string
+		reserve0  *big.Int
+		reserve1  *big.Int
+		fee       uint64
+		amountIn  *big.Int
+		tokenIn   common.Address
+		wantGT    string // result should be greater than this
+		wantLT    string // result should be less than this
+	}{
+		{
+			name:     "standard swap token0 to token1",
+			reserve0: new(big.Int).Mul(big.NewInt(10000), big.NewInt(1e18)), // 10000 tokens
+			reserve1: new(big.Int).Mul(big.NewInt(10000), big.NewInt(1e18)),
+			fee:      30, // 0.3%
+			amountIn: big.NewInt(1e18), // 1 token
+			tokenIn:  token0,
+			wantGT:   "990000000000000000",  // > 0.99 (fee impact)
+			wantLT:   "1000000000000000000", // < 1 (price impact)
+		},
+		{
+			name:     "swap token1 to token0",
+			reserve0: new(big.Int).Mul(big.NewInt(10000), big.NewInt(1e18)),
+			reserve1: new(big.Int).Mul(big.NewInt(10000), big.NewInt(1e18)),
+			fee:      30,
+			amountIn: big.NewInt(1e18),
+			tokenIn:  token1,
+			wantGT:   "990000000000000000",
+			wantLT:   "1000000000000000000",
+		},
+		{
+			name:     "large swap with price impact",
+			reserve0: new(big.Int).Mul(big.NewInt(1000), big.NewInt(1e18)), // 1000 tokens
+			reserve1: new(big.Int).Mul(big.NewInt(1000), big.NewInt(1e18)),
+			fee:      30,
+			amountIn: new(big.Int).Mul(big.NewInt(100), big.NewInt(1e18)), // 100 tokens (10%)
+			tokenIn:  token0,
+			wantGT:   "80000000000000000000",  // > 80 tokens
+			wantLT:   "100000000000000000000", // < 100 tokens (significant impact)
+		},
+		{
+			name:     "zero amount in",
+			reserve0: big.NewInt(1e18),
+			reserve1: big.NewInt(1e18),
+			fee:      30,
+			amountIn: big.NewInt(0),
+			tokenIn:  token0,
+			wantGT:   "-1", // >= 0
+			wantLT:   "1",  // < 1
+		},
+		{
+			name:     "different fee tier (0.05%)",
+			reserve0: new(big.Int).Mul(big.NewInt(10000), big.NewInt(1e18)),
+			reserve1: new(big.Int).Mul(big.NewInt(10000), big.NewInt(1e18)),
+			fee:      5, // 0.05%
+			amountIn: big.NewInt(1e18),
+			tokenIn:  token0,
+			wantGT:   "995000000000000000",  // > 0.995 (lower fee = more output)
+			wantLT:   "1000000000000000000",
+		},
+		{
+			name:     "high fee tier (1%)",
+			reserve0: new(big.Int).Mul(big.NewInt(10000), big.NewInt(1e18)),
+			reserve1: new(big.Int).Mul(big.NewInt(10000), big.NewInt(1e18)),
+			fee:      100, // 1%
+			amountIn: big.NewInt(1e18),
+			tokenIn:  token0,
+			wantGT:   "980000000000000000",  // > 0.98 (higher fee = less output)
+			wantLT:   "1000000000000000000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Pair{
+				Token0:   Token{Address: token0},
+				Token1:   Token{Address: token1},
+				Reserve0: tt.reserve0,
+				Reserve1: tt.reserve1,
+				Fee:      tt.fee,
+			}
+
+			got := p.GetAmountOut(tt.amountIn, tt.tokenIn)
+
+			wantGT, _ := new(big.Int).SetString(tt.wantGT, 10)
+			wantLT, _ := new(big.Int).SetString(tt.wantLT, 10)
+
+			if got.Cmp(wantGT) <= 0 {
+				t.Errorf("GetAmountOut() = %v, want > %v", got.String(), tt.wantGT)
+			}
+			if got.Cmp(wantLT) >= 0 {
+				t.Errorf("GetAmountOut() = %v, want < %v", got.String(), tt.wantLT)
+			}
+		})
+	}
+}
+
+func TestGetAmountOutWithNilReserves(t *testing.T) {
+	p := &Pair{
+		Token0:   Token{Address: common.HexToAddress("0x1")},
+		Token1:   Token{Address: common.HexToAddress("0x2")},
+		Reserve0: nil,
+		Reserve1: nil,
+		Fee:      30,
+	}
+
+	got := p.GetAmountOut(big.NewInt(1e18), p.Token0.Address)
+	if got.Sign() != 0 {
+		t.Errorf("GetAmountOut() with nil reserves = %v, want 0", got.String())
+	}
+}
+
+func TestGetAmountOutWithZeroReserves(t *testing.T) {
+	p := &Pair{
+		Token0:   Token{Address: common.HexToAddress("0x1")},
+		Token1:   Token{Address: common.HexToAddress("0x2")},
+		Reserve0: big.NewInt(0),
+		Reserve1: big.NewInt(1000),
+		Fee:      30,
+	}
+
+	got := p.GetAmountOut(big.NewInt(1e18), p.Token0.Address)
+	if got.Sign() != 0 {
+		t.Errorf("GetAmountOut() with zero reserveIn = %v, want 0", got.String())
+	}
+}

--- a/internal/domain/entities/token_loader.go
+++ b/internal/domain/entities/token_loader.go
@@ -1,0 +1,103 @@
+package entities
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// TokenConfig represents token configuration from JSON
+type TokenConfig struct {
+	Address  string `json:"address"`
+	Symbol   string `json:"symbol"`
+	Name     string `json:"name"`
+	Decimals uint8  `json:"decimals"`
+}
+
+// TokensConfig represents the tokens.json structure
+type TokensConfig struct {
+	Tokens []TokenConfig `json:"tokens"`
+}
+
+// TokenRegistry holds loaded tokens indexed by address and symbol
+type TokenRegistry struct {
+	byAddress map[common.Address]Token
+	bySymbol  map[string]Token
+	all       []Token
+}
+
+// NewTokenRegistry creates a new token registry
+func NewTokenRegistry() *TokenRegistry {
+	return &TokenRegistry{
+		byAddress: make(map[common.Address]Token),
+		bySymbol:  make(map[string]Token),
+		all:       make([]Token, 0),
+	}
+}
+
+// LoadFromFile loads tokens from a JSON config file
+func (r *TokenRegistry) LoadFromFile(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read token config: %w", err)
+	}
+
+	var config TokensConfig
+	if err := json.Unmarshal(data, &config); err != nil {
+		return fmt.Errorf("failed to parse token config: %w", err)
+	}
+
+	for _, tc := range config.Tokens {
+		token := Token{
+			Address:  common.HexToAddress(tc.Address),
+			Symbol:   tc.Symbol,
+			Name:     tc.Name,
+			Decimals: tc.Decimals,
+		}
+		r.Register(token)
+	}
+
+	return nil
+}
+
+// Register adds a token to the registry
+func (r *TokenRegistry) Register(token Token) {
+	r.byAddress[token.Address] = token
+	r.bySymbol[token.Symbol] = token
+	r.all = append(r.all, token)
+}
+
+// GetByAddress returns a token by its address
+func (r *TokenRegistry) GetByAddress(addr common.Address) (Token, bool) {
+	token, ok := r.byAddress[addr]
+	return token, ok
+}
+
+// GetBySymbol returns a token by its symbol
+func (r *TokenRegistry) GetBySymbol(symbol string) (Token, bool) {
+	token, ok := r.bySymbol[symbol]
+	return token, ok
+}
+
+// GetAll returns all registered tokens
+func (r *TokenRegistry) GetAll() []Token {
+	return r.all
+}
+
+// Count returns the number of registered tokens
+func (r *TokenRegistry) Count() int {
+	return len(r.all)
+}
+
+// DefaultRegistry returns a registry with hardcoded default tokens
+// Use this as fallback if config file is not available
+func DefaultRegistry() *TokenRegistry {
+	r := NewTokenRegistry()
+	r.Register(WETH)
+	r.Register(USDC)
+	r.Register(USDT)
+	r.Register(DAI)
+	return r
+}

--- a/internal/domain/services/router_service_test.go
+++ b/internal/domain/services/router_service_test.go
@@ -1,0 +1,251 @@
+package services
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/bimakw/dex-aggregator/internal/domain/entities"
+	"github.com/bimakw/dex-aggregator/internal/infrastructure/dex"
+)
+
+// MockDEXClient is a mock implementation of DEXClient for testing
+type MockDEXClient struct {
+	dexType   entities.DEXType
+	pairs     map[string]*entities.Pair
+	amountOut *big.Int
+	err       error
+}
+
+func NewMockDEXClient(dexType entities.DEXType) *MockDEXClient {
+	return &MockDEXClient{
+		dexType: dexType,
+		pairs:   make(map[string]*entities.Pair),
+	}
+}
+
+func (m *MockDEXClient) SetPair(tokenA, tokenB common.Address, pair *entities.Pair) {
+	key := pairKey(tokenA, tokenB)
+	m.pairs[key] = pair
+}
+
+func (m *MockDEXClient) SetAmountOut(amount *big.Int) {
+	m.amountOut = amount
+}
+
+func (m *MockDEXClient) SetError(err error) {
+	m.err = err
+}
+
+func pairKey(tokenA, tokenB common.Address) string {
+	if tokenA.Hex() < tokenB.Hex() {
+		return tokenA.Hex() + "-" + tokenB.Hex()
+	}
+	return tokenB.Hex() + "-" + tokenA.Hex()
+}
+
+func (m *MockDEXClient) GetPairAddress(ctx context.Context, tokenA, tokenB common.Address) (common.Address, error) {
+	if m.err != nil {
+		return common.Address{}, m.err
+	}
+	key := pairKey(tokenA, tokenB)
+	if pair, ok := m.pairs[key]; ok {
+		return pair.Address, nil
+	}
+	return common.Address{}, nil
+}
+
+func (m *MockDEXClient) GetPairByTokens(ctx context.Context, tokenA, tokenB entities.Token) (*entities.Pair, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	key := pairKey(tokenA.Address, tokenB.Address)
+	if pair, ok := m.pairs[key]; ok {
+		return pair, nil
+	}
+	return nil, nil
+}
+
+func (m *MockDEXClient) GetAmountOut(ctx context.Context, amountIn *big.Int, tokenIn, tokenOut entities.Token) (*big.Int, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.amountOut != nil {
+		return m.amountOut, nil
+	}
+	// Use pair's GetAmountOut if available
+	key := pairKey(tokenIn.Address, tokenOut.Address)
+	if pair, ok := m.pairs[key]; ok {
+		return pair.GetAmountOut(amountIn, tokenIn.Address), nil
+	}
+	return big.NewInt(0), nil
+}
+
+func (m *MockDEXClient) DEXType() entities.DEXType {
+	return m.dexType
+}
+
+// MockCache is a mock implementation of Cache for testing
+type MockCache struct{}
+
+func (m *MockCache) GetPair(ctx context.Context, key string) (*entities.Pair, error) {
+	return nil, nil // Always miss
+}
+
+func (m *MockCache) SetPair(ctx context.Context, key string, pair *entities.Pair, ttl time.Duration) error {
+	return nil
+}
+
+func (m *MockCache) GetPrice(ctx context.Context, key string) (string, error) {
+	return "", nil
+}
+
+func (m *MockCache) SetPrice(ctx context.Context, key string, price string, ttl time.Duration) error {
+	return nil
+}
+
+func (m *MockCache) Delete(ctx context.Context, key string) error {
+	return nil
+}
+
+func TestRouterServiceGetQuote(t *testing.T) {
+	token0 := entities.Token{
+		Address:  common.HexToAddress("0x0000000000000000000000000000000000000001"),
+		Symbol:   "TOKEN0",
+		Decimals: 18,
+	}
+	token1 := entities.Token{
+		Address:  common.HexToAddress("0x0000000000000000000000000000000000000002"),
+		Symbol:   "TOKEN1",
+		Decimals: 18,
+	}
+
+	// Create mock DEX clients
+	mockV2 := NewMockDEXClient(entities.DEXUniswapV2)
+	mockV3 := NewMockDEXClient(entities.DEXUniswapV3)
+	mockSushi := NewMockDEXClient(entities.DEXSushiswap)
+
+	// Set up pairs with different reserves (different prices)
+	pairV2 := &entities.Pair{
+		Address:  common.HexToAddress("0x1111"),
+		Token0:   token0,
+		Token1:   token1,
+		Reserve0: new(big.Int).Mul(big.NewInt(10000), big.NewInt(1e18)),
+		Reserve1: new(big.Int).Mul(big.NewInt(10000), big.NewInt(1e18)),
+		DEX:      entities.DEXUniswapV2,
+		Fee:      30, // 0.3%
+	}
+
+	pairV3 := &entities.Pair{
+		Address:  common.HexToAddress("0x2222"),
+		Token0:   token0,
+		Token1:   token1,
+		Reserve0: new(big.Int).Mul(big.NewInt(10000), big.NewInt(1e18)),
+		Reserve1: new(big.Int).Mul(big.NewInt(10200), big.NewInt(1e18)), // Slightly better rate
+		DEX:      entities.DEXUniswapV3,
+		Fee:      5, // 0.05%
+	}
+
+	pairSushi := &entities.Pair{
+		Address:  common.HexToAddress("0x3333"),
+		Token0:   token0,
+		Token1:   token1,
+		Reserve0: new(big.Int).Mul(big.NewInt(10000), big.NewInt(1e18)),
+		Reserve1: new(big.Int).Mul(big.NewInt(9900), big.NewInt(1e18)), // Slightly worse rate
+		DEX:      entities.DEXSushiswap,
+		Fee:      30, // 0.3%
+	}
+
+	mockV2.SetPair(token0.Address, token1.Address, pairV2)
+	mockV3.SetPair(token0.Address, token1.Address, pairV3)
+	mockSushi.SetPair(token0.Address, token1.Address, pairSushi)
+
+	// Create services
+	dexClients := []dex.DEXClient{mockV2, mockV3, mockSushi}
+	priceService := NewPriceService(dexClients, &MockCache{})
+	routerService := NewRouterService(priceService)
+
+	// Test GetQuote
+	amountIn := big.NewInt(1e18) // 1 token
+	quote, err := routerService.GetQuote(context.Background(), token0, token1, amountIn)
+
+	if err != nil {
+		t.Fatalf("GetQuote failed: %v", err)
+	}
+
+	if quote == nil {
+		t.Fatal("Quote is nil")
+	}
+
+	// Verify we have sources
+	if len(quote.Sources) == 0 {
+		t.Error("No sources in quote")
+	}
+
+	// Verify best route was selected (V3 should be best due to better reserves)
+	if quote.AmountOut == nil || quote.AmountOut.Sign() <= 0 {
+		t.Error("AmountOut should be positive")
+	}
+
+	t.Logf("Quote: AmountIn=%s, AmountOut=%s, BestDEX=%s",
+		quote.AmountIn.String(), quote.AmountOut.String(), quote.BestRoute.Hops[0].Pair.DEX)
+	t.Logf("Sources: %v", quote.Sources)
+}
+
+func TestRouterServiceNoValidRoutes(t *testing.T) {
+	token0 := entities.Token{
+		Address:  common.HexToAddress("0x0000000000000000000000000000000000000001"),
+		Symbol:   "TOKEN0",
+		Decimals: 18,
+	}
+	token1 := entities.Token{
+		Address:  common.HexToAddress("0x0000000000000000000000000000000000000002"),
+		Symbol:   "TOKEN1",
+		Decimals: 18,
+	}
+
+	// Create mock DEX client that returns error
+	mock := NewMockDEXClient(entities.DEXUniswapV2)
+	mock.SetError(context.DeadlineExceeded)
+
+	dexClients := []dex.DEXClient{mock}
+	priceService := NewPriceService(dexClients, &MockCache{})
+	routerService := NewRouterService(priceService)
+
+	_, err := routerService.GetQuote(context.Background(), token0, token1, big.NewInt(1e18))
+	if err == nil {
+		t.Error("Expected error for no valid routes, got nil")
+	}
+}
+
+func TestEstimateGas(t *testing.T) {
+	tests := []struct {
+		name string
+		hops int
+		want uint64
+	}{
+		{"nil route", 0, 150000},
+		{"single hop", 1, 121000},   // 21000 + 100000
+		{"two hops", 2, 221000},     // 21000 + 200000
+		{"three hops", 3, 321000},   // 21000 + 300000
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var route *entities.Route
+			if tt.hops > 0 {
+				route = &entities.Route{
+					Hops: make([]entities.Hop, tt.hops),
+				}
+			}
+
+			got := estimateGas(route)
+			if got != tt.want {
+				t.Errorf("estimateGas() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/dex/uniswap_v3.go
+++ b/internal/infrastructure/dex/uniswap_v3.go
@@ -1,0 +1,219 @@
+package dex
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/bimakw/dex-aggregator/internal/domain/entities"
+	ethclient "github.com/bimakw/dex-aggregator/internal/infrastructure/ethereum"
+)
+
+// Uniswap V3 contract addresses (Ethereum Mainnet)
+var (
+	UniswapV3FactoryAddress = common.HexToAddress("0x1F98431c8aD98523631AE4a59f267346ea31F984")
+	UniswapV3QuoterV2       = common.HexToAddress("0x61fFE014bA17989E743c5F6cB21bF9697530B21e")
+)
+
+// Uniswap V3 fee tiers in hundredths of a bip (1 = 0.0001%)
+var V3FeeTiers = []uint32{
+	100,   // 0.01%
+	500,   // 0.05%
+	3000,  // 0.30%
+	10000, // 1.00%
+}
+
+// Uniswap V3 ABI function selectors
+var (
+	// getPool(address,address,uint24) returns (address)
+	getPoolSelector = common.Hex2Bytes("1698ee82")
+	// quoteExactInputSingle((address,address,uint256,uint24,uint160)) returns (uint256,uint160,uint32,uint256)
+	quoteExactInputSingleSelector = common.Hex2Bytes("c6a5026a")
+)
+
+// UniswapV3Client fetches price data from Uniswap V3
+type UniswapV3Client struct {
+	ethClient *ethclient.Client
+	factory   common.Address
+	quoter    common.Address
+}
+
+// NewUniswapV3Client creates a new Uniswap V3 client
+func NewUniswapV3Client(ethClient *ethclient.Client) *UniswapV3Client {
+	return &UniswapV3Client{
+		ethClient: ethClient,
+		factory:   UniswapV3FactoryAddress,
+		quoter:    UniswapV3QuoterV2,
+	}
+}
+
+// GetPairAddress returns the pool address for two tokens with the best liquidity
+// Tries all fee tiers and returns the first existing pool
+func (c *UniswapV3Client) GetPairAddress(ctx context.Context, tokenA, tokenB common.Address) (common.Address, error) {
+	token0, token1 := sortTokens(tokenA, tokenB)
+
+	// Try each fee tier to find an existing pool
+	for _, fee := range V3FeeTiers {
+		poolAddr, err := c.getPool(ctx, token0, token1, fee)
+		if err != nil {
+			continue
+		}
+		if poolAddr != ethclient.ZeroAddress {
+			return poolAddr, nil
+		}
+	}
+
+	return common.Address{}, fmt.Errorf("no V3 pool found for token pair")
+}
+
+// getPool calls factory.getPool to get pool address for specific fee tier
+func (c *UniswapV3Client) getPool(ctx context.Context, token0, token1 common.Address, fee uint32) (common.Address, error) {
+	// Encode: getPool(address,address,uint24)
+	data := make([]byte, 100)
+	copy(data[0:4], getPoolSelector)
+	copy(data[16:36], token0.Bytes())
+	copy(data[48:68], token1.Bytes())
+	// fee is uint24, put in last 3 bytes of the 32-byte slot
+	feeBig := big.NewInt(int64(fee))
+	feeBytes := feeBig.Bytes()
+	copy(data[100-len(feeBytes):100], feeBytes)
+
+	result, err := c.ethClient.CallContract(ctx, ethereum.CallMsg{
+		To:   &c.factory,
+		Data: data,
+	})
+	if err != nil {
+		return common.Address{}, err
+	}
+
+	if len(result) < 32 {
+		return common.Address{}, fmt.Errorf("invalid response length")
+	}
+
+	return common.BytesToAddress(result[12:32]), nil
+}
+
+// GetPairByTokens returns a Pair struct with price info from the best fee tier
+func (c *UniswapV3Client) GetPairByTokens(ctx context.Context, tokenA, tokenB entities.Token) (*entities.Pair, error) {
+	token0, token1 := tokenA, tokenB
+	if tokenA.Address.Hex() > tokenB.Address.Hex() {
+		token0, token1 = tokenB, tokenA
+	}
+
+	// Find pool with best liquidity by checking each fee tier
+	var bestPool common.Address
+	var bestFee uint32
+
+	for _, fee := range V3FeeTiers {
+		poolAddr, err := c.getPool(ctx, token0.Address, token1.Address, fee)
+		if err != nil || poolAddr == ethclient.ZeroAddress {
+			continue
+		}
+		// Use first found pool (typically 0.3% has most liquidity)
+		bestPool = poolAddr
+		bestFee = fee
+		break
+	}
+
+	if bestPool == ethclient.ZeroAddress {
+		return nil, fmt.Errorf("no V3 pool found for token pair")
+	}
+
+	// V3 doesn't use reserves like V2, but we create a Pair struct for compatibility
+	// The actual price calculation happens in GetAmountOut via Quoter
+	return &entities.Pair{
+		Address:   bestPool,
+		Token0:    token0,
+		Token1:    token1,
+		Reserve0:  big.NewInt(0), // V3 uses concentrated liquidity, not reserves
+		Reserve1:  big.NewInt(0),
+		DEX:       entities.DEXUniswapV3,
+		Fee:       uint64(bestFee), // Fee in hundredths of a bip
+		UpdatedAt: time.Now().Unix(),
+	}, nil
+}
+
+// GetAmountOut calculates output amount using QuoterV2.quoteExactInputSingle
+func (c *UniswapV3Client) GetAmountOut(ctx context.Context, amountIn *big.Int, tokenIn, tokenOut entities.Token) (*big.Int, error) {
+	if amountIn == nil || amountIn.Sign() <= 0 {
+		return big.NewInt(0), nil
+	}
+
+	// Try each fee tier and return the best quote
+	var bestAmountOut *big.Int
+
+	for _, fee := range V3FeeTiers {
+		amountOut, err := c.quoteExactInputSingle(ctx, tokenIn.Address, tokenOut.Address, amountIn, fee)
+		if err != nil {
+			continue
+		}
+
+		if bestAmountOut == nil || amountOut.Cmp(bestAmountOut) > 0 {
+			bestAmountOut = amountOut
+		}
+	}
+
+	if bestAmountOut == nil {
+		return nil, fmt.Errorf("failed to get quote from any V3 pool")
+	}
+
+	return bestAmountOut, nil
+}
+
+// quoteExactInputSingle calls QuoterV2 to get exact output amount
+// Struct params: (tokenIn, tokenOut, amountIn, fee, sqrtPriceLimitX96)
+func (c *UniswapV3Client) quoteExactInputSingle(ctx context.Context, tokenIn, tokenOut common.Address, amountIn *big.Int, fee uint32) (*big.Int, error) {
+	// Build calldata for quoteExactInputSingle
+	// QuoteExactInputSingleParams struct:
+	// - tokenIn (address): 32 bytes
+	// - tokenOut (address): 32 bytes
+	// - amountIn (uint256): 32 bytes
+	// - fee (uint24): 32 bytes
+	// - sqrtPriceLimitX96 (uint160): 32 bytes
+
+	data := make([]byte, 4+32*5) // selector + 5 params
+	copy(data[0:4], quoteExactInputSingleSelector)
+
+	// tokenIn at offset 4
+	copy(data[4+12:4+32], tokenIn.Bytes())
+
+	// tokenOut at offset 36
+	copy(data[36+12:36+32], tokenOut.Bytes())
+
+	// amountIn at offset 68
+	amountInBytes := amountIn.Bytes()
+	copy(data[68+32-len(amountInBytes):68+32], amountInBytes)
+
+	// fee at offset 100
+	feeBig := big.NewInt(int64(fee))
+	feeBytes := feeBig.Bytes()
+	copy(data[100+32-len(feeBytes):100+32], feeBytes)
+
+	// sqrtPriceLimitX96 at offset 132 - set to 0 for no limit
+	// Already zero-initialized
+
+	result, err := c.ethClient.CallContract(ctx, ethereum.CallMsg{
+		To:   &c.quoter,
+		Data: data,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("quoter call failed: %w", err)
+	}
+
+	// Response: (amountOut uint256, sqrtPriceX96After uint160, initializedTicksCrossed uint32, gasEstimate uint256)
+	if len(result) < 32 {
+		return nil, fmt.Errorf("invalid quoter response length: %d", len(result))
+	}
+
+	amountOut := new(big.Int).SetBytes(result[0:32])
+	return amountOut, nil
+}
+
+// DEXType returns the DEX type identifier
+func (c *UniswapV3Client) DEXType() entities.DEXType {
+	return entities.DEXUniswapV3
+}


### PR DESCRIPTION
## Summary
- Add Uniswap V3 client with QuoterV2 integration for accurate price quotes
- Support all V3 fee tiers: 0.01%, 0.05%, 0.3%, and 1%
- Add configurable token list via `configs/tokens.json` with loader utility
- Add unit tests for Pair entity (GetSpotPrice, GetAmountOut) and RouterService
- Bump version to v0.2.0

## Changes
- `internal/infrastructure/dex/uniswap_v3.go` - New V3 client implementation
- `internal/domain/entities/token_loader.go` - Token config loader
- `configs/tokens.json` - Token list configuration
- `internal/domain/entities/pair_test.go` - Pair entity tests
- `internal/domain/services/router_service_test.go` - Router service tests
- `cmd/api/main.go` - Register V3 client + bump version

## Test plan
- [x] All unit tests pass (`go test ./...`)
- [x] Build succeeds (`go build ./...`)
- [ ] Manual test: query `/api/v1/quote` and verify `uniswap_v3` appears in sources